### PR TITLE
Add small splash & artifact workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build artifact
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Set up JDK 21 (or another version if needed)
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Step 3: Build with Maven
+      - name: Build with Maven
+        run: mvn clean package
+
+      # Step 4: Upload artifact
+      - name: Upload Plugin Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: minecraft-plugin
+          path: target/*.jar

--- a/src/main/java/net/coalcube/bansystem/bungee/BanSystemBungee.java
+++ b/src/main/java/net/coalcube/bansystem/bungee/BanSystemBungee.java
@@ -76,12 +76,17 @@ public class BanSystemBungee extends Plugin implements BanSystem {
         cachedBannedPlayerNames = new ArrayList<>();
         cachedMutedPlayerNames = new ArrayList<>();
 
-        console.sendMessage(new TextComponent("§c  ____                    ____                  _                      "));
-        console.sendMessage(new TextComponent("§c | __ )    __ _   _ __   / ___|   _   _   ___  | |_    ___   _ __ ___  "));
-        console.sendMessage(new TextComponent("§c |  _ \\   / _` | | '_ \\  \\___ \\  | | | | / __| | __|  / _ \\ | '_ ` _ \\ "));
-        console.sendMessage(new TextComponent("§c | |_) | | (_| | | | | |  ___) | | |_| | \\__ \\ | |_  |  __/ | | | | | |"));
-        console.sendMessage(new TextComponent("§c |____/   \\__,_| |_| |_| |____/   \\__, | |___/  \\__|  \\___| |_| |_| |_|"));
-        console.sendMessage(new TextComponent("§c                                  |___/                           §7v" + this.getVersion()));
+        File smallSplash = new File(getDataFolder(), ".smallsplash");
+        if (!smallSplash.exists()) {
+            console.sendMessage(new TextComponent("§c  ____                    ____                  _                      "));
+            console.sendMessage(new TextComponent("§c | __ )    __ _   _ __   / ___|   _   _   ___  | |_    ___   _ __ ___  "));
+            console.sendMessage(new TextComponent("§c |  _ \\   / _` | | '_ \\  \\___ \\  | | | | / __| | __|  / _ \\ | '_ ` _ \\ "));
+            console.sendMessage(new TextComponent("§c | |_) | | (_| | | | | |  ___) | | |_| | \\__ \\ | |_  |  __/ | | | | | |"));
+            console.sendMessage(new TextComponent("§c |____/   \\__,_| |_| |_| |____/   \\__, | |___/  \\__|  \\___| |_| |_| |_|"));
+            console.sendMessage(new TextComponent("§c                                  |___/                           §7v" + this.getVersion()));
+        } else {
+            console.sendMessage(new TextComponent(prefix + "BanSystem v" + this.getVersion() + " wird gestartet..."));
+        }
 
         try {
             configurationUtil.createConfigs(getDataFolder());

--- a/src/main/java/net/coalcube/bansystem/spigot/BanSystemSpigot.java
+++ b/src/main/java/net/coalcube/bansystem/spigot/BanSystemSpigot.java
@@ -77,12 +77,17 @@ public class BanSystemSpigot extends JavaPlugin implements BanSystem {
         cachedBannedPlayerNames = new ArrayList<>();
         cachedMutedPlayerNames = new ArrayList<>();
 
-        console.sendMessage("§c  ____                    ____                  _                      ");
-        console.sendMessage("§c | __ )    __ _   _ __   / ___|   _   _   ___  | |_    ___   _ __ ___  ");
-        console.sendMessage("§c |  _ \\   / _` | | '_ \\  \\___ \\  | | | | / __| | __|  / _ \\ | '_ ` _ \\ ");
-        console.sendMessage("§c | |_) | | (_| | | | | |  ___) | | |_| | \\__ \\ | |_  |  __/ | | | | | |");
-        console.sendMessage("§c |____/   \\__,_| |_| |_| |____/   \\__, | |___/  \\__|  \\___| |_| |_| |_|");
-        console.sendMessage("§c                                  |___/                           §7v" + this.getVersion());
+        File smallSplash = new File(getDataFolder(), ".smallsplash");
+        if (!smallSplash.exists()) {
+            console.sendMessage("§c  ____                    ____                  _                      ");
+            console.sendMessage("§c | __ )    __ _   _ __   / ___|   _   _   ___  | |_    ___   _ __ ___  ");
+            console.sendMessage("§c |  _ \\   / _` | | '_ \\  \\___ \\  | | | | / __| | __|  / _ \\ | '_ ` _ \\ ");
+            console.sendMessage("§c | |_) | | (_| | | | | |  ___) | | |_| | \\__ \\ | |_  |  __/ | | | | | |");
+            console.sendMessage("§c |____/   \\__,_| |_| |_| |____/   \\__, | |___/  \\__|  \\___| |_| |_| |_|");
+            console.sendMessage("§c                                  |___/                           §7v" + this.getVersion());
+        } else {
+            console.sendMessage(prefix + "BanSystem v" + this.getVersion() + " wird gestartet...");
+        }
 
         try {
             configurationUtil.createConfigs(getDataFolder());

--- a/src/main/java/net/coalcube/bansystem/velocity/BanSystemVelocity.java
+++ b/src/main/java/net/coalcube/bansystem/velocity/BanSystemVelocity.java
@@ -97,12 +97,17 @@ public class BanSystemVelocity implements BanSystem {
         cachedBannedPlayerNames = new ArrayList<>();
         cachedMutedPlayerNames = new ArrayList<>();
 
-        sendConsoleMessage("§c  ____                    ____                  _                      ");
-        sendConsoleMessage("§c | __ )    __ _   _ __   / ___|   _   _   ___  | |_    ___   _ __ ___  ");
-        sendConsoleMessage("§c |  _ \\   / _` | | '_ \\  \\___ \\  | | | | / __| | __|  / _ \\ | '_ ` _ \\ ");
-        sendConsoleMessage("§c | |_) | | (_| | | | | |  ___) | | |_| | \\__ \\ | |_  |  __/ | | | | | |");
-        sendConsoleMessage("§c |____/   \\__,_| |_| |_| |____/   \\__, | |___/  \\__|  \\___| |_| |_| |_|");
-        sendConsoleMessage("§c                                  |___/                           §7v" + this.getVersion());
+        File smallSplash = new File(dataDirectory.toFile(), ".smallsplash");
+        if (!smallSplash.exists()) {
+            sendConsoleMessage("§c  ____                    ____                  _                      ");
+            sendConsoleMessage("§c | __ )    __ _   _ __   / ___|   _   _   ___  | |_    ___   _ __ ___  ");
+            sendConsoleMessage("§c |  _ \\   / _` | | '_ \\  \\___ \\  | | | | / __| | __|  / _ \\ | '_ ` _ \\ ");
+            sendConsoleMessage("§c | |_) | | (_| | | | | |  ___) | | |_| | \\__ \\ | |_  |  __/ | | | | | |");
+            sendConsoleMessage("§c |____/   \\__,_| |_| |_| |____/   \\__, | |___/  \\__|  \\___| |_| |_| |_|");
+            sendConsoleMessage("§c                                  |___/                           §7v" + this.getVersion());
+        } else {
+            sendConsoleMessage(prefix + "BanSystem v" + this.getVersion() + " wird gestartet...");
+        }
 
         try {
             configurationUtil.createConfigs(dataDirectory.toFile());


### PR DESCRIPTION
My pull request includes the following:

 - A GitHub workflow for building artifacts in Actions
 - The ability to replace the big console art with a simple text by creating a ".smallsplash" file

I thought doing the whole file thing would be the better solution here so the startup text could still be shown before the config is initialized.