### PR TITLE
Fix/login listener npe

### DIFF
--- a/src/main/java/net/coalcube/bansystem/core/listener/LoginListener.java
+++ b/src/main/java/net/coalcube/bansystem/core/listener/LoginListener.java
@@ -60,6 +60,10 @@ public class LoginListener {
         String ip = inetAddress.getHostAddress();
         Ban ban = null;
 
+        if (!sql.isConnected()) {
+            return e;
+        }
+
         try {
             if (!banManager.isSavedBedrockPlayer(uuid) && UUIDFetcher.getName(uuid) == null) {
                 if (org.geysermc.floodgate.api.FloodgateApi.getInstance().getPlayer(uuid) != null) {


### PR DESCRIPTION
Problem:
A NullPointerException occurs in SQLite.getResult() because this.con is null when LoginListener.onJoin() is called from SpigotPlayerConnectionListener.onPreLogin().

java.lang.NullPointerException: Cannot invoke "java.sql.Connection.createStatement()" because "this.con" is null
    at net.coalcube.bansystem.core.sql.SQLite.getResult(SQLite.java:51)
    at net.coalcube.bansystem.core.ban.BanManagerSQLite.isSavedBedrockPlayer(BanManagerSQLite.java:482)
    at net.coalcube.bansystem.core.listener.LoginListener.onJoin(LoginListener.java:64)

Cause:
AsyncPlayerPreLoginEvent runs on an async thread pool. Although SpigotPlayerConnectionListener checks sql.isConnected() before calling onJoin(), the SQLite connection can become null between the check and the actual database access due to the non-thread-safe nature of SQLite connections.

Fix:
Added a sql.isConnected() guard at the start of LoginListener.onJoin() to safely return an empty event if the database connection is unavailable.
